### PR TITLE
SSE memory leaks

### DIFF
--- a/app/sse.js
+++ b/app/sse.js
@@ -40,7 +40,7 @@ function middleware(req, res, next) {
   }
 
   function ping() {
-    res.write('::\n\n');
+    res.write(':\n');
   }
 
   req.socket.setTimeout(Infinity);


### PR DESCRIPTION
En relisant le code du SSE je suis tombé sur quelques memory leaks :shit: :
- l'historique n'était pas réellement flushé (un slice dans le vide). 83cf63f3
- l'événement `end` des requêtes n'étant pas écouté, une connexion fermée par le serveur (ce qui ne devrait pas arriver mais sait-on jamais) ne supprimait ni le `setInterval` ni le binding event-emitter. ce4e192

J'en ai profité pour cleaner un peu (c'est du js...). J'ai pu tester rapidement sur mon environnement de dev, mais une vérification avant merge est la bienvenue :smiley:
