### PR TITLE
Add heroku support

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -137,3 +137,10 @@ module.exports = (grunt) ->
     'cssmin'
     'uglify'
   ]
+
+  # Heroku
+  # heroku config:add
+  # BUILDPACK_URL=https://github.com/jmreidy/heroku-buildpack-nodejs-grunt.git
+  grunt.registerTask 'heroku', [
+    'default'
+  ]

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node koalab.js

--- a/README.md
+++ b/README.md
@@ -72,6 +72,41 @@ In production, we are using:
 - and [mina](http://nadarei.co/mina/) for deployments.
 
 
+And for heroku?
+---------------
+
+- Add `config/server.json` to git (in a dedicated heroku branch if you want).
+
+    - Don't forget to set the persona audience value to your heroku app url.
+    - Mongodb part is not necessary.
+
+- Add an heroku buildpack for grunt :
+
+```
+heroku config:add BUILDPACK_URL=https://github.com/jmreidy/heroku-buildpack-nodejs-grunt.git
+```
+
+- Add a mongodb provider
+
+```
+heroku addons:add mongolab
+```
+
+for mongolab or for mongohq
+
+```
+heroku addons:add mongohq
+```
+
+- Deploy on heroku
+
+```
+git push heroku master
+```
+
+- Enjoy!
+
+
 Configuration
 -------------
 

--- a/koalab.js
+++ b/koalab.js
@@ -90,14 +90,19 @@ useSecret(function(secret) {
     app.use(express.methodOverride());
     app.use(app.router);
 
-    var db = mongoose.createConnection(config.mongodb.host, config.mongodb.database);
+    var uri = process.env.MONGOLAB_URI ||
+      process.env.MONGOHQ_URL ||
+      config.mongodb.host + "/" + config.mongodb.database;
+    var db = mongoose.createConnection(uri);
     db.on('error', function(err) {
       abort("Can't connect to mongodb: ", err);
     });
+    
+    var port = process.env.PORT || config.port;
     db.once('open', function () {
       require('./app/controller')(app, db, pass, config.demo);
-      app.listen(config.port, function() {
-        console.log('Express server listening on port ' + config.port);
+      app.listen(port, function() {
+        console.log('Express server listening on port ' + port);
       });
     });
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "Koalab",
   "version": "0.1.0",
+  "engines": {
+    "node": "0.10.x",
+    "npm": "1.3.x"
+  },
   "dependencies": {
     "mongoose": "~3.1",
     "paginate": "~0.1",
@@ -8,11 +12,11 @@
     "consolidate": "~0.4",
     "jade": "*",
     "passport": "~0.1",
-    "passport-browserid": "~0.1"
+    "passport-browserid": "~0.1",
+    "bower": "latest",
+    "grunt": "latest"
   },
   "devDependencies": {
-    "bower": "latest",
-    "grunt": "latest",
     "grunt-coffeelint": "latest",
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-coffee": "~0.6.4",
@@ -25,5 +29,8 @@
     "grunt-contrib-watch": "~0.3.1",
     "grunt-plato": "~0.2.0",
     "matchdep": "~0.1.2"
+  },
+  "scripts": {
+    "postinstall": "echo postinstall time; ./node_modules/.bin/bower install"
   }
 }


### PR DESCRIPTION
Allow to deploy on heroku.
- read heroku environment variables
- move grunt and bower to dependencies to have a postinstall task
- use grunt on heroku
- add a procfile
